### PR TITLE
Support HTML Like label syntax

### DIFF
--- a/src/model/__test__/Edge.spec.ts
+++ b/src/model/__test__/Edge.spec.ts
@@ -44,5 +44,17 @@ describe('class Edge', () => {
       edge = new DigraphEdge(node1, node2, node3, node1, node2, node3, node1, node2, node3);
       expect(edge.toDot()).toMatchSnapshot();
     });
+
+    describe('label attribute behavior', () => {
+      it('plain text label to be quoted by double quotation', () => {
+        edge.attributes.set('label', 'this is test');
+        expect(edge.toDot()).toMatchSnapshot();
+      });
+
+      it('html like', () => {
+        edge.attributes.set('label', '<<B>this is test</B>>');
+        expect(edge.toDot()).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/model/__test__/Node.spec.ts
+++ b/src/model/__test__/Node.spec.ts
@@ -23,5 +23,17 @@ describe('class Node', () => {
       node.attributes.set('color', 'red');
       expect(node.toDot()).toMatchSnapshot();
     });
+
+    describe('label attribute behavior', () => {
+      it('plain text label to be quoted by double quotation', () => {
+        node.attributes.set('label', 'this is test');
+        expect(node.toDot()).toMatchSnapshot();
+      });
+
+      it('html like', () => {
+        node.attributes.set('label', '<<B>this is test</B>>');
+        expect(node.toDot()).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/model/__test__/__snapshots__/Edge.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Edge.spec.ts.snap
@@ -18,4 +18,16 @@ exports[`class Edge renders correctly by toDot method has some attributes 1`] = 
 ];"
 `;
 
+exports[`class Edge renders correctly by toDot method label attribute behavior html like 1`] = `
+"\\"node1\\" -> \\"node2\\" [
+  label = <<B>this is test</B>>,
+];"
+`;
+
+exports[`class Edge renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"\\"node1\\" -> \\"node2\\" [
+  label = \\"this is test\\",
+];"
+`;
+
 exports[`class Edge renders correctly by toDot method simple edge 1`] = `"\\"node1\\" -> \\"node2\\";"`;

--- a/src/model/__test__/__snapshots__/Node.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Node.spec.ts.snap
@@ -7,4 +7,16 @@ exports[`class Node renders correctly by toDot method has some attributes 1`] = 
 ];"
 `;
 
+exports[`class Node renders correctly by toDot method label attribute behavior html like 1`] = `
+"\\"test\\" [
+  label = <<B>this is test</B>>,
+];"
+`;
+
+exports[`class Node renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"\\"test\\" [
+  label = \\"this is test\\",
+];"
+`;
+
 exports[`class Node renders correctly by toDot method simple node 1`] = `"\\"test\\";"`;

--- a/src/model/cluster/__test__/Digraph.spec.ts
+++ b/src/model/cluster/__test__/Digraph.spec.ts
@@ -79,5 +79,25 @@ describe('class Subgraph', () => {
       expect(dot).toMatchSnapshot();
       expect(dot).toBeValidDot();
     });
+
+    describe('label attribute behavior', () => {
+      it('plain text label to be quoted by double quotation', () => {
+        g.attributes.graph.set('label', 'this is test for graph label');
+        g.attributes.edge.set('label', 'this is test for edge label');
+        g.attributes.node.set('label', 'this is test for node label');
+        const dot = g.toDot();
+        expect(dot).toMatchSnapshot();
+        expect(dot).toBeValidDot();
+      });
+
+      it('html like', () => {
+        g.attributes.graph.set('label', '<<B>this is test for graph label</B>>');
+        g.attributes.edge.set('label', '<<U>this is test for edge label</U>>');
+        g.attributes.node.set('label', '<<I>this is test for node label</I>>');
+        const dot = g.toDot();
+        expect(dot).toMatchSnapshot();
+        expect(dot).toBeValidDot();
+      });
+    });
   });
 });

--- a/src/model/cluster/__test__/Graph.spec.ts
+++ b/src/model/cluster/__test__/Graph.spec.ts
@@ -79,5 +79,25 @@ describe('class Graph', () => {
       expect(dot).toMatchSnapshot();
       expect(dot).toBeValidDot();
     });
+
+    describe('label attribute behavior', () => {
+      it('plain text label to be quoted by double quotation', () => {
+        g.attributes.graph.set('label', 'this is test for graph label');
+        g.attributes.edge.set('label', 'this is test for edge label');
+        g.attributes.node.set('label', 'this is test for node label');
+        const dot = g.toDot();
+        expect(dot).toMatchSnapshot();
+        expect(dot).toBeValidDot();
+      });
+
+      it('html like', () => {
+        g.attributes.graph.set('label', '<<B>this is test for graph label</B>>');
+        g.attributes.edge.set('label', '<<U>this is test for edge label</U>>');
+        g.attributes.node.set('label', '<<I>this is test for node label</I>>');
+        const dot = g.toDot();
+        expect(dot).toMatchSnapshot();
+        expect(dot).toBeValidDot();
+      });
+    });
   });
 });

--- a/src/model/cluster/__test__/Subgraph.spec.ts
+++ b/src/model/cluster/__test__/Subgraph.spec.ts
@@ -1,3 +1,4 @@
+import 'jest-graphviz';
 import { DotBase, GraphvizObject } from '../../../common';
 import { Cluster, Subgraph } from '../Cluster';
 import { Digraph } from '../Digraph';
@@ -44,6 +45,24 @@ describe('class Subgraph', () => {
       it('should be subgraph cluster, when subgraph id is "cluster_test"', () => {
         subgraph = new Subgraph(g.context, 'cluster_test');
         expect(subgraph.isSubgraphCluster()).toBe(true);
+      });
+
+      describe('label attribute behavior', () => {
+        it('plain text label to be quoted by double quotation', () => {
+          subgraph.attributes.graph.set('label', 'this is test for graph label');
+          subgraph.attributes.edge.set('label', 'this is test for edge label');
+          subgraph.attributes.node.set('label', 'this is test for node label');
+          expect(subgraph.toDot()).toMatchSnapshot();
+          expect(g.toDot()).toBeValidDot();
+        });
+
+        it('html like', () => {
+          subgraph.attributes.graph.set('label', '<<B>this is test for graph label</B>>');
+          subgraph.attributes.edge.set('label', '<<U>this is test for edge label</U>>');
+          subgraph.attributes.node.set('label', '<<I>this is test for node label</I>>');
+          expect(subgraph.toDot()).toMatchSnapshot();
+          expect(g.toDot()).toBeValidDot();
+        });
       });
     });
   });

--- a/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
@@ -14,6 +14,34 @@ exports[`class Subgraph renders correctly by toDot method has some attributes 1`
 }"
 `;
 
+exports[`class Subgraph renders correctly by toDot method label attribute behavior html like 1`] = `
+"digraph G {
+  graph [
+    label = <<B>this is test for graph label</B>>,
+  ];
+  edge [
+    label = <<U>this is test for edge label</U>>,
+  ];
+  node [
+    label = <<I>this is test for node label</I>>,
+  ];
+}"
+`;
+
+exports[`class Subgraph renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"digraph G {
+  graph [
+    label = \\"this is test for graph label\\",
+  ];
+  edge [
+    label = \\"this is test for edge label\\",
+  ];
+  node [
+    label = \\"this is test for node label\\",
+  ];
+}"
+`;
+
 exports[`class Subgraph renders correctly by toDot method nodes and edge 1`] = `
 "digraph G {
   \\"node1\\";

--- a/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
@@ -14,6 +14,34 @@ exports[`class Graph renders correctly by toDot method has some attributes 1`] =
 }"
 `;
 
+exports[`class Graph renders correctly by toDot method label attribute behavior html like 1`] = `
+"graph G {
+  graph [
+    label = <<B>this is test for graph label</B>>,
+  ];
+  edge [
+    label = <<U>this is test for edge label</U>>,
+  ];
+  node [
+    label = <<I>this is test for node label</I>>,
+  ];
+}"
+`;
+
+exports[`class Graph renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"graph G {
+  graph [
+    label = \\"this is test for graph label\\",
+  ];
+  edge [
+    label = \\"this is test for edge label\\",
+  ];
+  node [
+    label = \\"this is test for node label\\",
+  ];
+}"
+`;
+
 exports[`class Graph renders correctly by toDot method nodes and edge 1`] = `
 "graph G {
   \\"node1\\";

--- a/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class Subgraph root is Digraph label attribute behavior html like 1`] = `
+"subgraph test {
+  graph [
+    label = <<B>this is test for graph label</B>>,
+  ];
+  edge [
+    label = <<U>this is test for edge label</U>>,
+  ];
+  node [
+    label = <<I>this is test for node label</I>>,
+  ];
+};"
+`;
+
+exports[`class Subgraph root is Digraph label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"subgraph test {
+  graph [
+    label = \\"this is test for graph label\\",
+  ];
+  edge [
+    label = \\"this is test for edge label\\",
+  ];
+  node [
+    label = \\"this is test for node label\\",
+  ];
+};"
+`;
+
+exports[`class Subgraph root is Graph label attribute behavior html like 1`] = `
+"subgraph test {
+  graph [
+    label = <<B>this is test for graph label</B>>,
+  ];
+  edge [
+    label = <<U>this is test for edge label</U>>,
+  ];
+  node [
+    label = <<I>this is test for node label</I>>,
+  ];
+};"
+`;
+
+exports[`class Subgraph root is Graph label attribute behavior plain text label to be quoted by double quotation 1`] = `
+"subgraph test {
+  graph [
+    label = \\"this is test for graph label\\",
+  ];
+  edge [
+    label = \\"this is test for edge label\\",
+  ];
+  node [
+    label = \\"this is test for node label\\",
+  ];
+};"
+`;

--- a/src/model/values/__test__/valueType.spec.ts
+++ b/src/model/values/__test__/valueType.spec.ts
@@ -1,0 +1,35 @@
+import { LblStringValue } from '../valueType';
+describe('valueType', () => {
+  describe('LblStringValue', () => {
+    describe('plain string', () => {
+      test.each([['test']])('toDot result should be quoted', input => {
+        const value = new LblStringValue(input);
+        const dot = value.toDot();
+        expect(dot).toMatch(/".+"/);
+        expect(dot).not.toMatch(/<.+>/);
+      });
+    });
+
+    describe('HTML Like string', () => {
+      test.each([
+        ['<<B>hoge</B>>'],
+        [
+          `<
+          <U>hoge</U>
+          >`,
+        ],
+        [
+          `
+          <<I>hoge</I>
+          >
+          `,
+        ],
+      ])('toDot result should not be quoted', input => {
+        const value = new LblStringValue(input);
+        const dot = value.toDot();
+        expect(dot).not.toMatch(/".+"/);
+        expect(dot).toMatch(/<.+>/);
+      });
+    });
+  });
+});

--- a/src/model/values/__test__/valueType.spec.ts
+++ b/src/model/values/__test__/valueType.spec.ts
@@ -1,12 +1,23 @@
 import { LblStringValue } from '../valueType';
+
+const DoubleQuotedValuePattern = /^".+"$/ms;
+const HTMLLikeValuePattern = /^<.+>$/ms;
+
 describe('valueType', () => {
   describe('LblStringValue', () => {
     describe('plain string', () => {
-      test.each([['test']])('toDot result should be quoted', input => {
+      test.each([
+        ['test'],
+        [
+          `
+          test
+          `,
+        ],
+      ])('toDot result should be quoted', input => {
         const value = new LblStringValue(input);
         const dot = value.toDot();
-        expect(dot).toMatch(/".+"/);
-        expect(dot).not.toMatch(/<.+>/);
+        expect(dot).toMatch(DoubleQuotedValuePattern);
+        expect(dot).not.toMatch(HTMLLikeValuePattern);
       });
     });
 
@@ -27,8 +38,8 @@ describe('valueType', () => {
       ])('toDot result should not be quoted', input => {
         const value = new LblStringValue(input);
         const dot = value.toDot();
-        expect(dot).not.toMatch(/".+"/);
-        expect(dot).toMatch(/<.+>/);
+        expect(dot).not.toMatch(DoubleQuotedValuePattern);
+        expect(dot).toMatch(HTMLLikeValuePattern);
       });
     });
   });

--- a/src/model/values/valueType.ts
+++ b/src/model/values/valueType.ts
@@ -86,8 +86,10 @@ export class LblStringValue extends GraphvizValue {
   private isHTMLLike: boolean;
   constructor(value: string);
   constructor(value: any) {
-    super(value);
-    this.isHTMLLike = /^<.+>$/.test(value);
+    const trimmed = value.trim();
+    const isHTMLLike = /^<.+>$/ms.test(trimmed);
+    super(isHTMLLike ? trimmed : value);
+    this.isHTMLLike = isHTMLLike;
   }
   public toDot(): string {
     if (this.isHTMLLike) {

--- a/src/model/values/valueType.ts
+++ b/src/model/values/valueType.ts
@@ -83,9 +83,16 @@ export class LayerRangeValue extends GraphvizValue {
  * @category Values
  */
 export class LblStringValue extends GraphvizValue {
+  private isHTMLLike: boolean;
   constructor(value: string);
-  constructor(value: any) { super(value); }
+  constructor(value: any) {
+    super(value);
+    this.isHTMLLike = /^<.+>$/.test(value);
+  }
   public toDot(): string {
+    if (this.isHTMLLike) {
+      return this.value.toString();
+    }
     return `"${this.value}"`;
   }
 }


### PR DESCRIPTION
## Code

```ts
const node = new Node('test');
node.attributes.set('label', '<<B>this is test</B>>');
console.log(node.toDot());
```

## Output

```dot
"test" [
  label = <<B>this is test</B>>,
];
```
