### PR TITLE
Add comment prop for graphviz objects

### DIFF
--- a/src/__test__/__snapshots__/usecase.spec.ts.snap
+++ b/src/__test__/__snapshots__/usecase.spec.ts.snap
@@ -24,6 +24,33 @@ exports[`function digraph callback style 1`] = `
 }"
 `;
 
+exports[`function digraph comment 1`] = `
+"// This is directed graph.
+digraph G {
+  // This is node a.
+  aa;
+  // This is node b.
+  bb;
+  // This is node c.
+  cc;
+  // It is subgraph A.
+  // It is not cluster
+  subgraph A {
+    // This is node Aaa in subgraph A.
+    Aaa [
+      // It will be filled by pink.
+      color = pink,
+    ];
+  };
+  // This is edge.
+  // It connects a, b and c.
+  aa -> bb -> cc [
+    // Edge line will draw with red.
+    color = red,
+  ];
+}"
+`;
+
 exports[`function graph callback style 1`] = `
 "graph G {
   aa;

--- a/src/__test__/usecase.spec.ts
+++ b/src/__test__/usecase.spec.ts
@@ -32,6 +32,34 @@ describe('function digraph', () => {
     const dot = G.toDot();
     expect(dot).toBeValidDotAndMatchSnapshot();
   });
+
+  test('comment', () => {
+    const G = digraph('G', g => {
+      g.comment = 'This is directed graph.';
+      const a = g.node('aa');
+      a.comment = 'This is node a.';
+      const b = g.node('bb');
+      b.comment = 'This is node b.';
+      const c = g.node('cc');
+      c.comment = 'This is node c.';
+      g.edge([a, b, c], e => {
+        e.comment = 'This is edge.\nIt connects a, b and c.';
+
+        e.attributes.set('color', 'red');
+        e.attributes.comment = 'Edge line will draw with red.';
+      });
+      g.subgraph('A', A => {
+        A.comment = 'It is subgraph A.\nIt is not cluster';
+        A.node('Aaa', n => {
+          n.comment = 'This is node Aaa in subgraph A.';
+          n.attributes.comment = 'It will be filled by pink.';
+          n.attributes.set('color', 'pink');
+        });
+      });
+    });
+    const dot = G.toDot();
+    expect(dot).toBeValidDotAndMatchSnapshot();
+  });
 });
 
 describe('function graph', () => {

--- a/src/model/Attributes.ts
+++ b/src/model/Attributes.ts
@@ -1,11 +1,12 @@
 import { DotBase } from '../common';
-import { indent } from '../utils/dot-rendering';
+import { commentOut, indent, joinLines } from '../utils/dot-rendering';
 import { Literal } from './Literal';
 
 /**
  * @category Attributes
  */
 export class Attributes extends DotBase {
+  public comment?: string;
   protected attrs: Map<string, Literal> = new Map();
   get size(): number {
     return this.attrs.size;
@@ -24,10 +25,12 @@ export class Attributes extends DotBase {
     if (this.size === 0) {
       return '';
     }
-    return [
+    const comment = this.comment ? indent(commentOut(this.comment)) : undefined;
+    return joinLines(
       '[',
+      comment,
       ...Array.from(this.attrs.entries()).map(([key, value]) => indent(`${key} = ${value.toDot()},`)),
       ']',
-    ].join('\n');
+    );
   }
 }

--- a/src/model/Edge.ts
+++ b/src/model/Edge.ts
@@ -1,5 +1,6 @@
 import { DotBase } from '../common';
 import { IEdgeTarget } from '../common/interface';
+import { commentOut, joinLines } from '../utils/dot-rendering';
 import { Attributes } from './Attributes';
 import { IContext } from './Context';
 import { isEdgeTarget } from './Node';
@@ -8,6 +9,8 @@ import { isEdgeTarget } from './Node';
  * @category Primary
  */
 export class Edge extends DotBase {
+  public comment?: string;
+
   public readonly attributes = new Attributes();
   public readonly targets: IEdgeTarget[];
 
@@ -19,10 +22,11 @@ export class Edge extends DotBase {
   }
 
   public toDot(): string {
+    const comment = this.comment ? commentOut(this.comment) : undefined;
     const arrow = this.context.graphType === 'digraph' ? '->' : '--';
     const target = this.targets.map(n => n.toEdgeTargetDot()).join(` ${arrow} `);
     const attrs = this.attributes.size > 0 ? ` ${this.attributes.toDot()}` : '';
-    const src = `${target}${attrs};`;
-    return src;
+    const dot = `${target}${attrs};`;
+    return joinLines(comment, dot);
   }
 }

--- a/src/model/Node.ts
+++ b/src/model/Node.ts
@@ -1,5 +1,6 @@
 import { DotBase } from '../common';
 import { IEdgeTarget } from '../common/interface';
+import { commentOut, joinLines } from '../utils/dot-rendering';
 import { Attributes } from './Attributes';
 import { Literal } from './Literal';
 
@@ -7,6 +8,7 @@ import { Literal } from './Literal';
  * @category Primary
  */
 export class Node extends DotBase implements IEdgeTarget {
+  public comment?: string;
   public readonly idLiteral: Literal;
   public readonly attributes = new Attributes();
   constructor(public readonly id: string) {
@@ -15,9 +17,11 @@ export class Node extends DotBase implements IEdgeTarget {
   }
 
   public toDot(): string {
+    const comment = this.comment ? commentOut(this.comment) : undefined;
     const target = this.idLiteral.toDot();
     const attrs = this.attributes.size > 0 ? ` ${this.attributes.toDot()}` : '';
-    return `${target}${attrs};`;
+    const dot = `${target}${attrs};`;
+    return joinLines(comment, dot);
   }
 
   public toEdgeTargetDot() {

--- a/src/model/__test__/Attributes.spec.ts
+++ b/src/model/__test__/Attributes.spec.ts
@@ -32,5 +32,21 @@ describe('class Attributes', () => {
       attrs.set('color', 'red');
       expect(attrs.toDot()).toMatchSnapshot();
     });
+
+    describe('edge with comment', () => {
+      beforeEach(() => {
+        attrs.set('label', 'test');
+        attrs.set('color', 'red');
+      });
+      test('single line comment', () => {
+        attrs.comment = 'this is comment.';
+        expect(attrs.toDot()).toMatchSnapshot();
+      });
+
+      test('multi line comment', () => {
+        attrs.comment = 'this is comment.\nsecond line.';
+        expect(attrs.toDot()).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/model/__test__/Edge.spec.ts
+++ b/src/model/__test__/Edge.spec.ts
@@ -22,6 +22,18 @@ describe('class Edge', () => {
       expect(edge.toDot()).toMatchSnapshot();
     });
 
+    describe('edge with comment', () => {
+      test('single line comment', () => {
+        edge.comment = 'this is comment.';
+        expect(edge.toDot()).toMatchSnapshot();
+      });
+
+      test('multi line comment', () => {
+        edge.comment = 'this is comment.\nsecond line.';
+        expect(edge.toDot()).toMatchSnapshot();
+      });
+    });
+
     it('should be escaped if id contains a newline character', () => {
       edge = new Edge({ graphType: 'digraph' }, node1, new Node('1\n2\n'));
       expect(edge.toDot()).toBe('node1 -> "1\\n2\\n";');

--- a/src/model/__test__/Node.spec.ts
+++ b/src/model/__test__/Node.spec.ts
@@ -18,6 +18,18 @@ describe('class Node', () => {
       expect(node.toDot()).toMatchSnapshot();
     });
 
+    describe('node with comment', () => {
+      test('single line comment', () => {
+        node.comment = 'this is comment.';
+        expect(node.toDot()).toMatchSnapshot();
+      });
+
+      test('multi line comment', () => {
+        node.comment = 'this is comment.\nsecond line.';
+        expect(node.toDot()).toMatchSnapshot();
+      });
+    });
+
     it('should be escaped if id contains a newline character', () => {
       node = new Node('1\n2\n');
       expect(node.toDot()).toBe('"1\\n2\\n";');

--- a/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class Attributes renders correctly by toDot method edge with comment multi line comment 1`] = `
+"[
+  // this is comment.
+  // second line.
+  label = test,
+  color = red,
+]"
+`;
+
+exports[`class Attributes renders correctly by toDot method edge with comment single line comment 1`] = `
+"[
+  // this is comment.
+  label = test,
+  color = red,
+]"
+`;
+
 exports[`class Attributes renders correctly by toDot method no attributes 1`] = `""`;
 
 exports[`class Attributes renders correctly by toDot method one attribute 1`] = `

--- a/src/model/__test__/__snapshots__/Edge.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Edge.spec.ts.snap
@@ -4,6 +4,17 @@ exports[`class Edge renders correctly by toDot method 3 nodes 1`] = `"node1 -> n
 
 exports[`class Edge renders correctly by toDot method 3 nodes, but many args 1`] = `"node1 -> node2 -> node3 -> node1 -> node2 -> node3 -> node1 -> node2 -> node3;"`;
 
+exports[`class Edge renders correctly by toDot method edge with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+node1 -> node2;"
+`;
+
+exports[`class Edge renders correctly by toDot method edge with comment single line comment 1`] = `
+"// this is comment.
+node1 -> node2;"
+`;
+
 exports[`class Edge renders correctly by toDot method graphType is "graph" 1`] = `
 "node1 -- node2 [
   label = \\"this is test\\",

--- a/src/model/__test__/__snapshots__/Node.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Node.spec.ts.snap
@@ -19,4 +19,15 @@ exports[`class Node renders correctly by toDot method label attribute behavior p
 ];"
 `;
 
+exports[`class Node renders correctly by toDot method node with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+test;"
+`;
+
+exports[`class Node renders correctly by toDot method node with comment single line comment 1`] = `
+"// this is comment.
+test;"
+`;
+
 exports[`class Node renders correctly by toDot method simple node 1`] = `"test;"`;

--- a/src/model/cluster/Cluster.ts
+++ b/src/model/cluster/Cluster.ts
@@ -1,6 +1,6 @@
 import { DotBase } from '../../common';
 import { IEdgeTarget } from '../../common/interface';
-import { concatWords, indent, joinLines } from '../../utils/dot-rendering';
+import { commentOut, concatWords, indent, joinLines } from '../../utils/dot-rendering';
 import { Attributes } from '../Attributes';
 import { Context } from '../Context';
 import { Edge } from '../Edge';
@@ -25,6 +25,7 @@ export interface IClusterCommonAttributes {
  * @hidden
  */
 export abstract class Cluster extends DotBase {
+  public comment?: string;
   get id(): string | undefined {
     return this.idLiteral?.value;
   }
@@ -168,6 +169,7 @@ export abstract class Cluster extends DotBase {
   }
 
   public toDot(): string {
+    const comment = this.comment ? commentOut(this.comment) : undefined;
     const type = this.type;
     const id = this.idLiteral?.toDot();
     // attributes
@@ -180,8 +182,13 @@ export abstract class Cluster extends DotBase {
     const subgraphs = Array.from(this.subgraphs.values()).map(o => o.toDot());
     const edges = Array.from(this.edges.values()).map(o => o.toDot());
     const clusterContents = joinLines(...commonAttributes, ...nodes, ...subgraphs, ...edges);
-    const src = joinLines(concatWords(type, id, '{'), clusterContents ? indent(clusterContents) : undefined, '}');
-    return src;
+    const dot = joinLines(
+      comment,
+      concatWords(type, id, '{'),
+      clusterContents ? indent(clusterContents) : undefined,
+      '}',
+    );
+    return dot;
   }
 
   private toNodeLikeObject(node: EdgeTargetLike): IEdgeTarget {

--- a/src/model/cluster/__test__/Digraph.spec.ts
+++ b/src/model/cluster/__test__/Digraph.spec.ts
@@ -5,7 +5,7 @@ import { Node } from '../../Node';
 import { Cluster, RootCluster } from '../Cluster';
 import { Digraph } from '../Digraph';
 
-describe('class Subgraph', () => {
+describe('class Digraph', () => {
   let g: Digraph;
   beforeEach(() => {
     g = new Digraph();
@@ -23,6 +23,18 @@ describe('class Subgraph', () => {
     it('simple g', () => {
       const dot = g.toDot();
       expect(dot).toBeValidDotAndMatchSnapshot();
+    });
+
+    describe('digraph with comment', () => {
+      test('single line comment', () => {
+        g.comment = 'this is comment.';
+        expect(g.toDot()).toMatchSnapshot();
+      });
+
+      test('multi line comment', () => {
+        g.comment = 'this is comment.\nsecond line.';
+        expect(g.toDot()).toMatchSnapshot();
+      });
     });
 
     it('should be escaped if id contains a newline character', () => {

--- a/src/model/cluster/__test__/Graph.spec.ts
+++ b/src/model/cluster/__test__/Graph.spec.ts
@@ -25,6 +25,18 @@ describe('class Graph', () => {
       expect(dot).toBeValidDotAndMatchSnapshot();
     });
 
+    describe('graph with comment', () => {
+      test('single line comment', () => {
+        g.comment = 'this is comment.';
+        expect(g.toDot()).toMatchSnapshot();
+      });
+
+      test('multi line comment', () => {
+        g.comment = 'this is comment.\nsecond line.';
+        expect(g.toDot()).toMatchSnapshot();
+      });
+    });
+
     it('should be escaped if id contains a newline character', () => {
       g = new Graph('1\n2\n');
       const dot = g.toDot();

--- a/src/model/cluster/__test__/Subgraph.spec.ts
+++ b/src/model/cluster/__test__/Subgraph.spec.ts
@@ -47,6 +47,18 @@ describe('class Subgraph', () => {
         expect(subgraph.isSubgraphCluster()).toBe(false);
       });
 
+      describe('subgraph with comment', () => {
+        test('single line comment', () => {
+          subgraph.comment = 'this is comment.';
+          expect(subgraph.toDot()).toMatchSnapshot();
+        });
+
+        test('multi line comment', () => {
+          subgraph.comment = 'this is comment.\nsecond line.';
+          expect(subgraph.toDot()).toMatchSnapshot();
+        });
+      });
+
       it('should be escaped if id contains a newline character', () => {
         subgraph = new Subgraph(g.context);
         subgraph.id = '1\n2\n';

--- a/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`class Subgraph renders correctly by toDot method has some attributes 1`] = `
+exports[`class Digraph renders correctly by toDot method digraph with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+digraph {
+}"
+`;
+
+exports[`class Digraph renders correctly by toDot method digraph with comment single line comment 1`] = `
+"// this is comment.
+digraph {
+}"
+`;
+
+exports[`class Digraph renders correctly by toDot method has some attributes 1`] = `
 "digraph {
   graph [
     color = red,
@@ -14,7 +27,7 @@ exports[`class Subgraph renders correctly by toDot method has some attributes 1`
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method label attribute behavior html like 1`] = `
+exports[`class Digraph renders correctly by toDot method label attribute behavior html like 1`] = `
 "digraph {
   graph [
     label = <<B>this is test for graph label</B>>,
@@ -28,7 +41,7 @@ exports[`class Subgraph renders correctly by toDot method label attribute behavi
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
+exports[`class Digraph renders correctly by toDot method label attribute behavior plain text label to be quoted by double quotation 1`] = `
 "digraph {
   graph [
     label = \\"this is test for graph label\\",
@@ -42,7 +55,7 @@ exports[`class Subgraph renders correctly by toDot method label attribute behavi
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method nodes and edge 1`] = `
+exports[`class Digraph renders correctly by toDot method nodes and edge 1`] = `
 "digraph {
   node1;
   node2;
@@ -50,22 +63,22 @@ exports[`class Subgraph renders correctly by toDot method nodes and edge 1`] = `
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method should be escaped if id contains a comma 1`] = `
+exports[`class Digraph renders correctly by toDot method should be escaped if id contains a comma 1`] = `
 "digraph \\"1\\\\\\"2\\\\\\"\\" {
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method should be escaped if id contains a newline character 1`] = `
+exports[`class Digraph renders correctly by toDot method should be escaped if id contains a newline character 1`] = `
 "digraph \\"1\\\\n2\\\\n\\" {
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method simple g 1`] = `
+exports[`class Digraph renders correctly by toDot method simple g 1`] = `
 "digraph {
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method subgraphs 1`] = `
+exports[`class Digraph renders correctly by toDot method subgraphs 1`] = `
 "digraph {
   node1;
   node2;
@@ -83,7 +96,7 @@ exports[`class Subgraph renders correctly by toDot method subgraphs 1`] = `
 }"
 `;
 
-exports[`class Subgraph renders correctly by toDot method subgraphs, depth 2 1`] = `
+exports[`class Digraph renders correctly by toDot method subgraphs, depth 2 1`] = `
 "digraph {
   node1;
   node2;

--- a/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class Graph renders correctly by toDot method graph with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+graph {
+}"
+`;
+
+exports[`class Graph renders correctly by toDot method graph with comment single line comment 1`] = `
+"// this is comment.
+graph {
+}"
+`;
+
 exports[`class Graph renders correctly by toDot method has some attributes 1`] = `
 "graph {
   graph [

--- a/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
@@ -53,6 +53,19 @@ exports[`class Subgraph root is Digraph should be escaped if id contains a newli
 }"
 `;
 
+exports[`class Subgraph root is Digraph subgraph with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+subgraph test {
+};"
+`;
+
+exports[`class Subgraph root is Digraph subgraph with comment single line comment 1`] = `
+"// this is comment.
+subgraph test {
+};"
+`;
+
 exports[`class Subgraph root is Graph addXxx existXxx removeXxx APIs Edge operation methods works 1`] = `
 "subgraph test {
   node1;
@@ -104,4 +117,17 @@ exports[`class Subgraph root is Graph should be escaped if id contains a comma 1
 exports[`class Subgraph root is Graph should be escaped if id contains a newline character 1`] = `
 "graph {
 }"
+`;
+
+exports[`class Subgraph root is Graph subgraph with comment multi line comment 1`] = `
+"// this is comment.
+// second line.
+subgraph test {
+};"
+`;
+
+exports[`class Subgraph root is Graph subgraph with comment single line comment 1`] = `
+"// this is comment.
+subgraph test {
+};"
 `;

--- a/src/utils/dot-rendering.ts
+++ b/src/utils/dot-rendering.ts
@@ -36,3 +36,13 @@ export function indent(src: string, depth: number = 1): string {
     .map(l => `${space}${l}`)
     .join('\n');
 }
+
+/**
+ * @hidden
+ */
+export function commentOut(src: string): string {
+  return src
+    .split('\n')
+    .map(l => `// ${l}`.trim())
+    .join('\n');
+}


### PR DESCRIPTION
```typescript
const G = digraph('G', g => {
  g.comment = 'This is directed graph.';
  const a = g.node('aa');
  a.comment = 'This is node a.';
  const b = g.node('bb');
  b.comment = 'This is node b.';
  const c = g.node('cc');
  c.comment = 'This is node c.';
  g.edge([a, b, c], e => {
    e.comment = 'This is edge.\nIt connects a, b and c.';

    e.attributes.set('color', 'red');
    e.attributes.comment = 'Edge line will draw with red.';
  });
  g.subgraph('A', A => {
    A.comment = 'It is subgraph A.\nIt is not cluster';
    A.node('Aaa', n => {
      n.comment = 'This is node Aaa in subgraph A.';
      n.attributes.comment = 'It will be filled by pink.';
      n.attributes.set('color', 'pink');
    });
  });
});
```

### Output

```dot
// This is directed graph.
digraph G {
  // This is node a.
  aa;
  // This is node b.
  bb;
  // This is node c.
  cc;
  // It is subgraph A.
  // It is not cluster
  subgraph A {
    // This is node Aaa in subgraph A.
    Aaa [
      // It will be filled by pink.
      color = pink,
    ];
  };
  // This is edge.
  // It connects a, b and c.
  aa -> bb -> cc [
    // Edge line will draw with red.
    color = red,
  ];
}
```