### PR TITLE
Support compass port

### DIFF
--- a/src/__test__/__snapshots__/usecase.spec.ts.snap
+++ b/src/__test__/__snapshots__/usecase.spec.ts.snap
@@ -68,6 +68,9 @@ exports[`function graph callback style 1`] = `
     Aaa -- Abb -- Acc -- hoge:fuga [
       color = red,
     ];
+    Aaa:a:w -- Abb:w -- Aaa:e -- Acc:r:e [
+      color = red,
+    ];
   };
   aa -- bb -- cc [
     color = red,

--- a/src/__test__/usecase.spec.ts
+++ b/src/__test__/usecase.spec.ts
@@ -87,6 +87,10 @@ describe('function graph', () => {
         A.edge([Aa, Ab, Ac, A.node('hoge').port('fuga')], e => {
           e.attributes.set('color', 'red');
         });
+
+        A.edge([Aa.port({ port: 'a', compass: 'w' }), Ab.port({ compass: 'w' }), 'Aaa:e', 'Acc:r:e'], e => {
+          e.attributes.set('color', 'red');
+        });
       });
     });
     const dot = G.toDot();

--- a/src/model/Node.ts
+++ b/src/model/Node.ts
@@ -5,10 +5,27 @@ import { Attributes } from './Attributes';
 import { Literal } from './Literal';
 
 type Compass = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c';
+// tslint:disable-next-line: no-namespace
+namespace Compass {
+  export const n: Compass = 'n';
+  export const ne: Compass = 'ne';
+  export const e: Compass = 'e';
+  export const se: Compass = 'se';
+  export const s: Compass = 's';
+  export const sw: Compass = 'sw';
+  export const w: Compass = 'w';
+  export const nw: Compass = 'nw';
+  export const c: Compass = 'c';
+  export const all: string[] = [n, ne, e, se, s, sw, w, nw, c];
+}
+
+export function isCompass(str: string): str is Compass {
+  return Compass.all.includes(str);
+}
 
 interface IPort {
   port: string;
-  compass: Compass | string;
+  compass: Compass;
 }
 
 /**
@@ -46,7 +63,7 @@ export class Node extends DotBase implements IEdgeTarget {
 // tslint:disable-next-line: max-classes-per-file
 export class NodeWithPort implements IEdgeTarget {
   public readonly port?: Literal;
-  public readonly compass?: Compass | string;
+  public readonly compass?: Compass;
   constructor(public readonly node: Node, port: Partial<IPort>) {
     this.port = port.port ? new Literal(port.port) : undefined;
     this.compass = port.compass;

--- a/src/model/Node.ts
+++ b/src/model/Node.ts
@@ -1,8 +1,15 @@
 import { DotBase } from '../common';
 import { IEdgeTarget } from '../common/interface';
-import { commentOut, joinLines } from '../utils/dot-rendering';
+import { commentOut, concatWordsWithColon, joinLines } from '../utils/dot-rendering';
 import { Attributes } from './Attributes';
 import { Literal } from './Literal';
+
+type Compass = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c';
+
+interface IPort {
+  port: string;
+  compass: Compass | string;
+}
 
 /**
  * @category Primary
@@ -28,20 +35,25 @@ export class Node extends DotBase implements IEdgeTarget {
     return this.idLiteral.toDot();
   }
 
-  public port(port: string): NodeWithPort {
+  public port(port: string | Partial<IPort>): NodeWithPort {
+    if (typeof port === 'string') {
+      return new NodeWithPort(this, { port });
+    }
     return new NodeWithPort(this, port);
   }
 }
 
 // tslint:disable-next-line: max-classes-per-file
 export class NodeWithPort implements IEdgeTarget {
-  public readonly port: Literal;
-  constructor(public readonly node: Node, port: string) {
-    this.port = new Literal(port);
+  public readonly port?: Literal;
+  public readonly compass?: Compass | string;
+  constructor(public readonly node: Node, port: Partial<IPort>) {
+    this.port = port.port ? new Literal(port.port) : undefined;
+    this.compass = port.compass;
   }
 
   public toEdgeTargetDot() {
-    return `${this.node.idLiteral.toDot()}:${this.port.toDot()}`;
+    return concatWordsWithColon(this.node.idLiteral.toDot(), this.port?.toDot(), this.compass);
   }
 }
 

--- a/src/model/cluster/Cluster.ts
+++ b/src/model/cluster/Cluster.ts
@@ -1,6 +1,6 @@
 import { DotBase } from '../../common';
 import { IEdgeTarget } from '../../common/interface';
-import { commentOut, concatWords, indent, joinLines } from '../../utils/dot-rendering';
+import { commentOut, concatWordsWithSpace, indent, joinLines } from '../../utils/dot-rendering';
 import { Attributes } from '../Attributes';
 import { Context } from '../Context';
 import { Edge } from '../Edge';
@@ -184,7 +184,7 @@ export abstract class Cluster extends DotBase {
     const clusterContents = joinLines(...commonAttributes, ...nodes, ...subgraphs, ...edges);
     const dot = joinLines(
       comment,
-      concatWords(type, id, '{'),
+      concatWordsWithSpace(type, id, '{'),
       clusterContents ? indent(clusterContents) : undefined,
       '}',
     );
@@ -196,10 +196,10 @@ export abstract class Cluster extends DotBase {
       return node;
     }
     // FIXME
-    const [id, port] = node.split(':');
+    const [id, port, compass] = node.split(':');
     const n = this.node(id);
     if (port) {
-      return n.port(port);
+      return n.port({ port, compass });
     }
     return n;
   }

--- a/src/model/cluster/Cluster.ts
+++ b/src/model/cluster/Cluster.ts
@@ -195,7 +195,6 @@ export abstract class Cluster extends DotBase {
     if (isEdgeTarget(node)) {
       return node;
     }
-    // FIXME
     const [id, port, compass] = node.split(':');
     const n = this.node(id);
     if (port) {

--- a/src/model/cluster/Cluster.ts
+++ b/src/model/cluster/Cluster.ts
@@ -5,7 +5,7 @@ import { Attributes } from '../Attributes';
 import { Context } from '../Context';
 import { Edge } from '../Edge';
 import { Literal } from '../Literal';
-import { EdgeTargetLike, isEdgeTarget, isEdgeTargetLike, Node } from '../Node';
+import { EdgeTargetLike, isCompass, isEdgeTarget, isEdgeTargetLike, Node } from '../Node';
 
 // tslint:disable: max-classes-per-file
 
@@ -197,7 +197,7 @@ export abstract class Cluster extends DotBase {
     }
     const [id, port, compass] = node.split(':');
     const n = this.node(id);
-    if (port) {
+    if (port && (compass === undefined || isCompass(compass))) {
       return n.port({ port, compass });
     }
     return n;

--- a/src/utils/dot-rendering.ts
+++ b/src/utils/dot-rendering.ts
@@ -15,16 +15,24 @@ export function quote(src: string): string {
 /**
  * @hidden
  */
-export function concatWords(...lines: (string | undefined)[]): string {
-  return lines.filter(l => typeof l === 'string').join(' ');
+function concatWordsFactory(deciliter: string): (...lines: (string | undefined)[]) => string {
+  return (...lines: (string | undefined)[]) => lines.filter(l => typeof l === 'string').join(deciliter);
 }
 
 /**
  * @hidden
  */
-export function joinLines(...lines: (string | undefined)[]): string {
-  return lines.filter(l => typeof l === 'string').join('\n');
-}
+export const concatWordsWithSpace = concatWordsFactory(' ');
+
+/**
+ * @hidden
+ */
+export const concatWordsWithColon = concatWordsFactory(':');
+
+/**
+ * @hidden
+ */
+export const joinLines = concatWordsFactory('\n');
 
 /**
  * @hidden


### PR DESCRIPTION
## Examples

```typescript
import { Node } from 'ts-graphviz';
const node = new Node('example');

// API that already exists
node.port('port').toDot();
// Output:
// example:port

// APIs supported this time
node.port({ port: 'port', compass: 'w' }).toDot();
// Output:
// example:port:w
```
