### PR TITLE
Add attributes APIs

### DIFF
--- a/src/model/Attributes.ts
+++ b/src/model/Attributes.ts
@@ -1,34 +1,15 @@
-import { DotBase } from '../common';
 import { commentOut, indent, joinLines } from '../utils/dot-rendering';
-import { ID } from './ID';
+import { AttributesBase } from './AttributesBase';
 
 /**
  * A set of attribute values for any object.
  *
  * @category Attributes
  */
-export class Attributes extends DotBase {
+export class Attributes extends AttributesBase {
   /** Comments to include when outputting with toDot. */
   public comment?: string;
-  /** @hidden */
-  protected attrs: Map<string, ID> = new Map();
-  /** The size of the attribute. */
-  get size(): number {
-    return this.attrs.size;
-  }
 
-  /** The size of the attribute. */
-  public get(key: string): ID | undefined {
-    return this.attrs.get(key);
-  }
-  /** Set a value to the attribute. */
-  public set(key: string, value: any): void {
-    if (value instanceof ID) {
-      this.attrs.set(key, value);
-    } else {
-      this.attrs.set(key, new ID(value));
-    }
-  }
   /** Convert Attributes to Dot language. */
   public toDot(): string {
     if (this.size === 0) {

--- a/src/model/AttributesBase.ts
+++ b/src/model/AttributesBase.ts
@@ -15,11 +15,17 @@ export abstract class AttributesBase extends DotBase {
     return this.attrs.get(key);
   }
   /** Set a value to the attribute. */
-  public set(key: string, value: any): void {
+  public set(key: string, value: string | boolean | number | ID): void {
     if (value instanceof ID) {
       this.attrs.set(key, value);
     } else {
       this.attrs.set(key, new ID(value));
+    }
+  }
+
+  public apply(attributes: { [key: string]: string | boolean | number | ID }) {
+    for (const [key, value] of Object.entries(attributes)) {
+      this.set(key, value);
     }
   }
 }

--- a/src/model/AttributesBase.ts
+++ b/src/model/AttributesBase.ts
@@ -1,0 +1,25 @@
+import { DotBase } from '../common';
+import { ID } from './ID';
+/**
+ * @hidden
+ */
+export abstract class AttributesBase extends DotBase {
+  /** @hidden */
+  protected attrs: Map<string, ID> = new Map();
+  /** The size of the attribute. */
+  get size(): number {
+    return this.attrs.size;
+  }
+  /** The size of the attribute. */
+  public get(key: string): ID | undefined {
+    return this.attrs.get(key);
+  }
+  /** Set a value to the attribute. */
+  public set(key: string, value: any): void {
+    if (value instanceof ID) {
+      this.attrs.set(key, value);
+    } else {
+      this.attrs.set(key, new ID(value));
+    }
+  }
+}

--- a/src/model/__test__/Attributes.spec.ts
+++ b/src/model/__test__/Attributes.spec.ts
@@ -33,6 +33,15 @@ describe('class Attributes', () => {
       expect(attrs.toDot()).toMatchSnapshot();
     });
 
+    test('set some attributes by apply', () => {
+      attrs.apply({
+        label: 'this is test',
+        color: 'red',
+        fontsize: 16,
+      });
+      expect(attrs.toDot()).toMatchSnapshot();
+    });
+
     describe('edge with comment', () => {
       beforeEach(() => {
         attrs.set('label', 'test');

--- a/src/model/__test__/Attributes.spec.ts
+++ b/src/model/__test__/Attributes.spec.ts
@@ -1,5 +1,6 @@
 import { DotBase, GraphvizObject } from '../../common';
 import { Attributes } from '../Attributes';
+import { AttributesBase } from '../AttributesBase';
 
 describe('class Attributes', () => {
   let attrs: Attributes;
@@ -7,8 +8,9 @@ describe('class Attributes', () => {
     attrs = new Attributes();
   });
 
-  it('should be instance of Attributes/DotBase/GraphvizObject', () => {
+  it('should be instance of Attributes/AttributesBase/DotBase/GraphvizObject', () => {
     expect(attrs).toBeInstanceOf(Attributes);
+    expect(attrs).toBeInstanceOf(AttributesBase);
     expect(attrs).toBeInstanceOf(DotBase);
     expect(attrs).toBeInstanceOf(GraphvizObject);
   });

--- a/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
@@ -25,6 +25,14 @@ exports[`class Attributes renders correctly by toDot method one attribute 1`] = 
 ]"
 `;
 
+exports[`class Attributes renders correctly by toDot method set some attributes by apply 1`] = `
+"[
+  label = \\"this is test\\",
+  color = red,
+  fontsize = 16,
+]"
+`;
+
 exports[`class Attributes renders correctly by toDot method some attributes 1`] = `
 "[
   label = test,

--- a/src/model/cluster/Cluster.ts
+++ b/src/model/cluster/Cluster.ts
@@ -1,7 +1,8 @@
-import { ClusterType, DotBase, isCompass, RootClusterType } from '../../common';
+import { ClusterType, isCompass, RootClusterType } from '../../common';
 import { IEdgeTarget } from '../../common/interface';
 import { commentOut, concatWordsWithSpace, indent, joinLines } from '../../utils/dot-rendering';
 import { Attributes } from '../Attributes';
+import { AttributesBase } from '../AttributesBase';
 import { Context } from '../Context';
 import { Edge } from '../Edge';
 import { ID } from '../ID';
@@ -26,7 +27,7 @@ export interface IClusterCommonAttributes {
  * Base class for clusters.
  * @hidden
  */
-export abstract class Cluster extends DotBase {
+export abstract class Cluster extends AttributesBase {
   /** Cluster ID */
   get id(): string | undefined {
     return this.idLiteral?.value;
@@ -279,15 +280,16 @@ export abstract class Cluster extends DotBase {
     const type = this.type;
     const id = this.idLiteral?.toDot();
     // attributes
+    const attributes = Array.from(this.attrs.entries()).map(([key, value]) => `${key} = ${value.toDot()};`);
     const commonAttributes = Object.entries(this.attributes)
-      .filter(([_, attributes]) => attributes.size > 0)
-      .map(([key, attributes]) => `${key} ${attributes.toDot()};`);
+      .filter(([_, attrs]) => attrs.size > 0)
+      .map(([key, attrs]) => `${key} ${attrs.toDot()};`);
 
     // objects
     const nodes = Array.from(this.nodes.values()).map(o => o.toDot());
     const subgraphs = Array.from(this.subgraphs.values()).map(o => o.toDot());
     const edges = Array.from(this.edges.values()).map(o => o.toDot());
-    const clusterContents = joinLines(...commonAttributes, ...nodes, ...subgraphs, ...edges);
+    const clusterContents = joinLines(...attributes, ...commonAttributes, ...nodes, ...subgraphs, ...edges);
     const dot = joinLines(
       concatWordsWithSpace(type, id, '{'),
       clusterContents ? indent(clusterContents) : undefined,

--- a/src/model/cluster/__test__/Digraph.spec.ts
+++ b/src/model/cluster/__test__/Digraph.spec.ts
@@ -39,6 +39,15 @@ describe('class Digraph', () => {
       expect(dot).toBeValidDotAndMatchSnapshot();
     });
 
+    test('set attributes by apply', () => {
+      g.apply({
+        layout: 'dot',
+        dpi: 360,
+      });
+      const dot = g.toDot();
+      expect(dot).toBeValidDotAndMatchSnapshot();
+    });
+
     describe('digraph with comment', () => {
       test('single line comment', () => {
         g.comment = 'this is comment.';

--- a/src/model/cluster/__test__/Digraph.spec.ts
+++ b/src/model/cluster/__test__/Digraph.spec.ts
@@ -1,5 +1,6 @@
 import 'jest-graphviz';
 import { DotBase, GraphvizObject, RootClusterType } from '../../../common';
+import { AttributesBase } from '../../AttributesBase';
 import { Edge } from '../../Edge';
 import { Node } from '../../Node';
 import { Cluster, RootCluster } from '../Cluster';
@@ -11,10 +12,11 @@ describe('class Digraph', () => {
     g = new Digraph();
   });
 
-  it('should be instance of Digraph/RootCluster/Cluster/DotBase/GraphvizObject', () => {
+  it('should be instance of Digraph/RootCluster/Cluster/AttributesBase/DotBase/GraphvizObject', () => {
     expect(g).toBeInstanceOf(Digraph);
     expect(g).toBeInstanceOf(RootCluster);
     expect(g).toBeInstanceOf(Cluster);
+    expect(g).toBeInstanceOf(AttributesBase);
     expect(g).toBeInstanceOf(DotBase);
     expect(g).toBeInstanceOf(GraphvizObject);
   });
@@ -27,6 +29,12 @@ describe('class Digraph', () => {
 
     it('strict graph', () => {
       g.strict = true;
+      const dot = g.toDot();
+      expect(dot).toBeValidDotAndMatchSnapshot();
+    });
+
+    test('set attributes', () => {
+      g.set('dpi', 360);
       const dot = g.toDot();
       expect(dot).toBeValidDotAndMatchSnapshot();
     });

--- a/src/model/cluster/__test__/Graph.spec.ts
+++ b/src/model/cluster/__test__/Graph.spec.ts
@@ -1,5 +1,6 @@
 import 'jest-graphviz';
 import { DotBase, GraphvizObject, RootClusterType } from '../../../common';
+import { AttributesBase } from '../../AttributesBase';
 import { Edge } from '../../Edge';
 import { Node } from '../../Node';
 import { Cluster, RootCluster } from '../Cluster';
@@ -11,10 +12,11 @@ describe('class Graph', () => {
     g = new Graph();
   });
 
-  it('should be instance of Graph/RootCluster/Cluster/DotBase/GraphvizObject', () => {
+  it('should be instance of Graph/RootCluster/Cluster/AttributesBase/DotBase/GraphvizObject', () => {
     expect(g).toBeInstanceOf(Graph);
     expect(g).toBeInstanceOf(RootCluster);
     expect(g).toBeInstanceOf(Cluster);
+    expect(g).toBeInstanceOf(AttributesBase);
     expect(g).toBeInstanceOf(DotBase);
     expect(g).toBeInstanceOf(GraphvizObject);
   });
@@ -27,6 +29,12 @@ describe('class Graph', () => {
 
     it('strict graph', () => {
       g.strict = true;
+      const dot = g.toDot();
+      expect(dot).toBeValidDotAndMatchSnapshot();
+    });
+
+    test('set attributes', () => {
+      g.set('dpi', 360);
       const dot = g.toDot();
       expect(dot).toBeValidDotAndMatchSnapshot();
     });

--- a/src/model/cluster/__test__/Graph.spec.ts
+++ b/src/model/cluster/__test__/Graph.spec.ts
@@ -39,6 +39,15 @@ describe('class Graph', () => {
       expect(dot).toBeValidDotAndMatchSnapshot();
     });
 
+    test('set attributes by apply', () => {
+      g.apply({
+        layout: 'dot',
+        dpi: 360,
+      });
+      const dot = g.toDot();
+      expect(dot).toBeValidDotAndMatchSnapshot();
+    });
+
     describe('graph with comment', () => {
       test('single line comment', () => {
         g.comment = 'this is comment.';

--- a/src/model/cluster/__test__/Subgraph.spec.ts
+++ b/src/model/cluster/__test__/Subgraph.spec.ts
@@ -51,6 +51,14 @@ describe('class Subgraph', () => {
         expect(dot).toBeValidDotAndMatchSnapshot();
       });
 
+      test('set attributes by apply', () => {
+        g.apply({
+          rank: 'same',
+        });
+        const dot = g.toDot();
+        expect(dot).toBeValidDotAndMatchSnapshot();
+      });
+
       it('should be subgraph, when subgraph id is "test"', () => {
         subgraph = g.context.createSubgraph('test');
         expect(subgraph.isSubgraphCluster()).toBe(false);

--- a/src/model/cluster/__test__/Subgraph.spec.ts
+++ b/src/model/cluster/__test__/Subgraph.spec.ts
@@ -1,5 +1,6 @@
 import 'jest-graphviz';
 import { DotBase, GraphvizObject } from '../../../common';
+import { AttributesBase } from '../../AttributesBase';
 import { Edge } from '../../Edge';
 import { Node } from '../../Node';
 import { Cluster, Subgraph } from '../Cluster';
@@ -35,11 +36,19 @@ describe('class Subgraph', () => {
         subgraph = g.context.createSubgraph('test');
       });
 
-      it('should be instance of Subgraph/Cluster/DotBase/GraphvizObject', () => {
+      it('should be instance of Subgraph/Cluster/AttributesBase/DotBase/GraphvizObject', () => {
         expect(subgraph).toBeInstanceOf(Subgraph);
         expect(subgraph).toBeInstanceOf(Cluster);
+        expect(subgraph).toBeInstanceOf(AttributesBase);
         expect(subgraph).toBeInstanceOf(DotBase);
         expect(subgraph).toBeInstanceOf(GraphvizObject);
+      });
+
+      test('set attributes', () => {
+        subgraph.set('rank', 'same');
+        g.addSubgraph(subgraph);
+        const dot = g.toDot();
+        expect(dot).toBeValidDotAndMatchSnapshot();
       });
 
       it('should be subgraph, when subgraph id is "test"', () => {

--- a/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
@@ -63,6 +63,12 @@ exports[`class Digraph renders correctly by toDot method nodes and edge 1`] = `
 }"
 `;
 
+exports[`class Digraph renders correctly by toDot method set attributes 1`] = `
+"digraph {
+  dpi = 360;
+}"
+`;
+
 exports[`class Digraph renders correctly by toDot method simple g 1`] = `
 "digraph {
 }"

--- a/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Digraph.spec.ts.snap
@@ -69,6 +69,13 @@ exports[`class Digraph renders correctly by toDot method set attributes 1`] = `
 }"
 `;
 
+exports[`class Digraph renders correctly by toDot method set attributes by apply 1`] = `
+"digraph {
+  layout = dot;
+  dpi = 360;
+}"
+`;
+
 exports[`class Digraph renders correctly by toDot method simple g 1`] = `
 "digraph {
 }"

--- a/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
@@ -63,6 +63,12 @@ exports[`class Graph renders correctly by toDot method nodes and edge 1`] = `
 }"
 `;
 
+exports[`class Graph renders correctly by toDot method set attributes 1`] = `
+"graph {
+  dpi = 360;
+}"
+`;
+
 exports[`class Graph renders correctly by toDot method simple g 1`] = `
 "graph {
 }"

--- a/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Graph.spec.ts.snap
@@ -69,6 +69,13 @@ exports[`class Graph renders correctly by toDot method set attributes 1`] = `
 }"
 `;
 
+exports[`class Graph renders correctly by toDot method set attributes by apply 1`] = `
+"graph {
+  layout = dot;
+  dpi = 360;
+}"
+`;
+
 exports[`class Graph renders correctly by toDot method simple g 1`] = `
 "graph {
 }"

--- a/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
@@ -43,6 +43,14 @@ exports[`class Subgraph root is Digraph label attribute behavior plain text labe
 }"
 `;
 
+exports[`class Subgraph root is Digraph set attributes 1`] = `
+"digraph {
+  subgraph test {
+    rank = same;
+  }
+}"
+`;
+
 exports[`class Subgraph root is Digraph subgraph with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
@@ -96,6 +104,14 @@ exports[`class Subgraph root is Graph label attribute behavior plain text label 
   node [
     label = \\"this is test for node label\\",
   ];
+}"
+`;
+
+exports[`class Subgraph root is Graph set attributes 1`] = `
+"graph {
+  subgraph test {
+    rank = same;
+  }
 }"
 `;
 

--- a/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
+++ b/src/model/cluster/__test__/__snapshots__/Subgraph.spec.ts.snap
@@ -51,6 +51,12 @@ exports[`class Subgraph root is Digraph set attributes 1`] = `
 }"
 `;
 
+exports[`class Subgraph root is Digraph set attributes by apply 1`] = `
+"digraph {
+  rank = same;
+}"
+`;
+
 exports[`class Subgraph root is Digraph subgraph with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
@@ -112,6 +118,12 @@ exports[`class Subgraph root is Graph set attributes 1`] = `
   subgraph test {
     rank = same;
   }
+}"
+`;
+
+exports[`class Subgraph root is Graph set attributes by apply 1`] = `
+"graph {
+  rank = same;
 }"
 `;
 


### PR DESCRIPTION
## Add cluster attributes

```typescript
const g = new Digraph();
g.apply({
  layout: 'dot',
  dpi: 360,
});
g.toDot();
// digraph {
//   layout = dot;
//   dpi = 360;
// }
```

## Add apply method to Attributes

Enable to set attributes at once with object

```typescript
const attrs = new Attributes();
attrs.apply({
  label: 'this is test',
  color: 'red',
  fontsize: 16,
});
attrs.toDot();
// [
//  label = \\"this is test\\",
//  color = red,
//  fontsize = 16,
// ]
```
