### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "unpkg": "lib/bundle.min.js",
+  "types": "lib/index.d.ts",
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
### What was a problem

`types` field, not exists in package.json.

<https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package>

### How this PR fixes the problem

Add types field to package.json.

`lib/index.d.ts`


### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
