### PR TITLE
fix: use quote for IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,20 @@ console.log(dot);
 ### Output
 
 ```graphviz
-digraph G {
-  node1;
-  node2;
-  subgraph A {
-    A_node1;
-    A_node2;
-    A_node1 -> A_node2;
-    B_node1 -> B_node2;
-  };
-  subgraph B {
-    B_node1;
-    B_node2;
-  };
-  node1 -> node2;
+digraph "G" {
+  "node1";
+  "node2";
+  subgraph "A" {
+    "A_node1";
+    "A_node2";
+    "A_node1" -> "A_node2";
+  }
+  subgraph "B" {
+    "B_node1";
+    "B_node2";
+    "B_node1" -> "B_node2";
+  }
+  "node1" -> "node2";
 }
 ```
 

--- a/src/__test__/__snapshots__/usecase.spec.ts.snap
+++ b/src/__test__/__snapshots__/usecase.spec.ts.snap
@@ -1,79 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`function digraph callback style 1`] = `
-"digraph G {
-  aa;
-  bb;
-  cc;
-  subgraph A {
-    Aaa [
-      color = pink,
+"digraph \\"G\\" {
+  \\"aa\\";
+  \\"bb\\";
+  \\"cc\\";
+  subgraph \\"A\\" {
+    \\"Aaa\\" [
+      color = \\"pink\\",
     ];
-    Abb [
-      color = violet,
+    \\"Abb\\" [
+      color = \\"violet\\",
     ];
-    Acc;
-    E;
-    Aaa:a -> Abb -> Acc -> E [
-      color = red,
+    \\"Acc\\";
+    \\"E\\";
+    \\"Aaa\\":\\"a\\" -> \\"Abb\\" -> \\"Acc\\" -> \\"E\\" [
+      color = \\"red\\",
     ];
   }
-  aa -> bb -> cc [
-    color = red,
+  \\"aa\\" -> \\"bb\\" -> \\"cc\\" [
+    color = \\"red\\",
   ];
 }"
 `;
 
 exports[`function digraph comment 1`] = `
 "// This is directed graph.
-digraph G {
+digraph \\"G\\" {
   // This is node a.
-  aa;
+  \\"aa\\";
   // This is node b.
-  bb;
+  \\"bb\\";
   // This is node c.
-  cc;
+  \\"cc\\";
   // It is subgraph A.
   // It is not cluster
-  subgraph A {
+  subgraph \\"A\\" {
     // This is node Aaa in subgraph A.
-    Aaa [
+    \\"Aaa\\" [
       // It will be filled by pink.
-      color = pink,
+      color = \\"pink\\",
     ];
   }
   // This is edge.
   // It connects a, b and c.
-  aa -> bb -> cc [
+  \\"aa\\" -> \\"bb\\" -> \\"cc\\" [
     // Edge line will draw with red.
-    color = red,
+    color = \\"red\\",
   ];
 }"
 `;
 
 exports[`function graph callback style 1`] = `
-"graph G {
-  aa;
-  bb;
-  cc;
-  subgraph A {
-    Aaa [
-      color = pink,
+"graph \\"G\\" {
+  \\"aa\\";
+  \\"bb\\";
+  \\"cc\\";
+  subgraph \\"A\\" {
+    \\"Aaa\\" [
+      color = \\"pink\\",
     ];
-    Abb [
-      color = violet,
+    \\"Abb\\" [
+      color = \\"violet\\",
     ];
-    Acc;
-    hoge;
-    Aaa -- Abb -- Acc -- hoge:fuga [
-      color = red,
+    \\"Acc\\";
+    \\"hoge\\";
+    \\"Aaa\\" -- \\"Abb\\" -- \\"Acc\\" -- \\"hoge\\":\\"fuga\\" [
+      color = \\"red\\",
     ];
-    Aaa:a:w -- Abb:w -- Aaa:e -- Acc:r:e [
-      color = red,
+    \\"Aaa\\":\\"a\\":w -- \\"Abb\\":w -- \\"Aaa\\":\\"e\\" -- \\"Acc\\":\\"r\\":e [
+      color = \\"red\\",
     ];
   }
-  aa -- bb -- cc [
-    color = red,
+  \\"aa\\" -- \\"bb\\" -- \\"cc\\" [
+    color = \\"red\\",
   ];
 }"
 `;
@@ -85,8 +85,17 @@ exports[`function graph escape characters 1`] = `
   ];
   \\"b\\\\\\"b\\";
   \\"c\\\\nc\\\\\\"\\";
+  subgraph \\"graph.name\\" {
+    \\"node.name\\" [
+      label = \\"node\\",
+    ];
+    \\"another.name\\" [
+      label = \\"words with space and \\\\\\"quote\\\\\\"\\",
+    ];
+    \\"node.name\\" -- \\"another.name\\";
+  }
   \\"a\\\\na\\" -- \\"b\\\\\\"b\\" -- \\"c\\\\nc\\\\\\"\\" [
-    color = red,
+    color = \\"red\\",
   ];
 }"
 `;

--- a/src/__test__/usecase.spec.ts
+++ b/src/__test__/usecase.spec.ts
@@ -106,6 +106,14 @@ describe('function graph', () => {
       g.edge([a, b, c], e => {
         e.attributes.set('color', 'red');
       });
+
+      g.subgraph('graph.name', s => {
+        const innerA = s.node('node.name');
+        innerA.attributes.set('label', 'node');
+        const innerB = s.node('another.name');
+        innerB.attributes.set('label', 'words with space and "quote"');
+        s.edge([innerA, innerB]);
+      });
     });
     const dot = G.toDot();
     expect(dot).toBeValidDotAndMatchSnapshot();

--- a/src/model/ID.ts
+++ b/src/model/ID.ts
@@ -40,7 +40,7 @@ export class ID extends DotBase implements IID {
         stringValue = trimmed;
         this.isQuoteRequired = false;
       } else {
-        this.isQuoteRequired = /[#\s":;=\-'/]/g.test(stringValue);
+        this.isQuoteRequired = true;
       }
     }
     this.value = stringValue;

--- a/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Attributes.spec.ts.snap
@@ -4,16 +4,16 @@ exports[`class Attributes renders correctly by toDot method edge with comment mu
 "[
   // this is comment.
   // second line.
-  label = test,
-  color = red,
+  label = \\"test\\",
+  color = \\"red\\",
 ]"
 `;
 
 exports[`class Attributes renders correctly by toDot method edge with comment single line comment 1`] = `
 "[
   // this is comment.
-  label = test,
-  color = red,
+  label = \\"test\\",
+  color = \\"red\\",
 ]"
 `;
 
@@ -21,21 +21,21 @@ exports[`class Attributes renders correctly by toDot method no attributes 1`] = 
 
 exports[`class Attributes renders correctly by toDot method one attribute 1`] = `
 "[
-  label = test,
+  label = \\"test\\",
 ]"
 `;
 
 exports[`class Attributes renders correctly by toDot method set some attributes by apply 1`] = `
 "[
   label = \\"this is test\\",
-  color = red,
+  color = \\"red\\",
   fontsize = 16,
 ]"
 `;
 
 exports[`class Attributes renders correctly by toDot method some attributes 1`] = `
 "[
-  label = test,
-  color = red,
+  label = \\"test\\",
+  color = \\"red\\",
 ]"
 `;

--- a/src/model/__test__/__snapshots__/Digraph.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Digraph.spec.ts.snap
@@ -16,7 +16,7 @@ digraph {
 exports[`class Digraph renders correctly by toDot method has some attributes 1`] = `
 "digraph {
   graph [
-    color = red,
+    color = \\"red\\",
   ];
   edge [
     label = \\"edge label\\",
@@ -57,9 +57,9 @@ exports[`class Digraph renders correctly by toDot method label attribute behavio
 
 exports[`class Digraph renders correctly by toDot method nodes and edge 1`] = `
 "digraph {
-  node1;
-  node2;
-  node1 -> node2;
+  \\"node1\\";
+  \\"node2\\";
+  \\"node1\\" -> \\"node2\\";
 }"
 `;
 
@@ -71,7 +71,7 @@ exports[`class Digraph renders correctly by toDot method set attributes 1`] = `
 
 exports[`class Digraph renders correctly by toDot method set attributes by apply 1`] = `
 "digraph {
-  layout = dot;
+  layout = \\"dot\\";
   dpi = 360;
 }"
 `;
@@ -88,36 +88,36 @@ exports[`class Digraph renders correctly by toDot method strict graph 1`] = `
 
 exports[`class Digraph renders correctly by toDot method subgraphs 1`] = `
 "digraph {
-  node1;
-  node2;
-  subgraph A {
-    A_node1;
-    A_node2;
-    A_node1 -> A_node2;
-    B_node1 -> B_node2;
+  \\"node1\\";
+  \\"node2\\";
+  subgraph \\"A\\" {
+    \\"A_node1\\";
+    \\"A_node2\\";
+    \\"A_node1\\" -> \\"A_node2\\";
+    \\"B_node1\\" -> \\"B_node2\\";
   }
-  subgraph B {
-    B_node1;
-    B_node2;
+  subgraph \\"B\\" {
+    \\"B_node1\\";
+    \\"B_node2\\";
   }
-  node1 -> node2;
+  \\"node1\\" -> \\"node2\\";
 }"
 `;
 
 exports[`class Digraph renders correctly by toDot method subgraphs, depth 2 1`] = `
 "digraph {
-  node1;
-  node2;
-  subgraph depth1 {
-    depth1_node1;
-    depth1_node2;
-    subgraph depth2 {
-      depth2_node1;
-      depth2_node2;
-      depth2_node1 -> depth2_node2;
+  \\"node1\\";
+  \\"node2\\";
+  subgraph \\"depth1\\" {
+    \\"depth1_node1\\";
+    \\"depth1_node2\\";
+    subgraph \\"depth2\\" {
+      \\"depth2_node1\\";
+      \\"depth2_node2\\";
+      \\"depth2_node1\\" -> \\"depth2_node2\\";
     }
-    depth1_node1 -> depth1_node2;
+    \\"depth1_node1\\" -> \\"depth1_node2\\";
   }
-  node1 -> node2;
+  \\"node1\\" -> \\"node2\\";
 }"
 `;

--- a/src/model/__test__/__snapshots__/Edge.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Edge.spec.ts.snap
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`class Edge renders correctly by toDot method 3 nodes 1`] = `"node1 -> node2 -> node3;"`;
+exports[`class Edge renders correctly by toDot method 3 nodes 1`] = `"\\"node1\\" -> \\"node2\\" -> \\"node3\\";"`;
 
-exports[`class Edge renders correctly by toDot method 3 nodes, but many args 1`] = `"node1 -> node2 -> node3 -> node1 -> node2 -> node3 -> node1 -> node2 -> node3;"`;
+exports[`class Edge renders correctly by toDot method 3 nodes, but many args 1`] = `"\\"node1\\" -> \\"node2\\" -> \\"node3\\" -> \\"node1\\" -> \\"node2\\" -> \\"node3\\" -> \\"node1\\" -> \\"node2\\" -> \\"node3\\";"`;
 
 exports[`class Edge renders correctly by toDot method edge with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
-node1 -> node2;"
+\\"node1\\" -> \\"node2\\";"
 `;
 
 exports[`class Edge renders correctly by toDot method edge with comment single line comment 1`] = `
 "// this is comment.
-node1 -> node2;"
+\\"node1\\" -> \\"node2\\";"
 `;
 
 exports[`class Edge renders correctly by toDot method graphType is "graph" 1`] = `
-"node1 -- node2 [
+"\\"node1\\" -- \\"node2\\" [
   label = \\"this is test\\",
-  color = red,
+  color = \\"red\\",
 ];"
 `;
 
 exports[`class Edge renders correctly by toDot method has some attributes 1`] = `
-"node1 -> node2 [
+"\\"node1\\" -> \\"node2\\" [
   label = \\"this is test\\",
-  color = red,
+  color = \\"red\\",
 ];"
 `;
 
-exports[`class Edge renders correctly by toDot method simple edge 1`] = `"node1 -> node2;"`;
+exports[`class Edge renders correctly by toDot method simple edge 1`] = `"\\"node1\\" -> \\"node2\\";"`;

--- a/src/model/__test__/__snapshots__/Graph.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Graph.spec.ts.snap
@@ -16,7 +16,7 @@ graph {
 exports[`class Graph renders correctly by toDot method has some attributes 1`] = `
 "graph {
   graph [
-    color = red,
+    color = \\"red\\",
   ];
   edge [
     label = \\"edge label\\",
@@ -57,9 +57,9 @@ exports[`class Graph renders correctly by toDot method label attribute behavior 
 
 exports[`class Graph renders correctly by toDot method nodes and edge 1`] = `
 "graph {
-  node1;
-  node2;
-  node1 -- node2;
+  \\"node1\\";
+  \\"node2\\";
+  \\"node1\\" -- \\"node2\\";
 }"
 `;
 
@@ -71,7 +71,7 @@ exports[`class Graph renders correctly by toDot method set attributes 1`] = `
 
 exports[`class Graph renders correctly by toDot method set attributes by apply 1`] = `
 "graph {
-  layout = dot;
+  layout = \\"dot\\";
   dpi = 360;
 }"
 `;
@@ -88,36 +88,36 @@ exports[`class Graph renders correctly by toDot method strict graph 1`] = `
 
 exports[`class Graph renders correctly by toDot method subgraphs 1`] = `
 "graph {
-  node1;
-  node2;
-  subgraph A {
-    A_node1;
-    A_node2;
-    A_node1 -- A_node2;
-    B_node1 -- B_node2;
+  \\"node1\\";
+  \\"node2\\";
+  subgraph \\"A\\" {
+    \\"A_node1\\";
+    \\"A_node2\\";
+    \\"A_node1\\" -- \\"A_node2\\";
+    \\"B_node1\\" -- \\"B_node2\\";
   }
-  subgraph B {
-    B_node1;
-    B_node2;
+  subgraph \\"B\\" {
+    \\"B_node1\\";
+    \\"B_node2\\";
   }
-  node1 -- node2;
+  \\"node1\\" -- \\"node2\\";
 }"
 `;
 
 exports[`class Graph renders correctly by toDot method subgraphs, depth 2 1`] = `
 "graph {
-  node1;
-  node2;
-  subgraph depth1 {
-    depth1_node1;
-    depth1_node2;
-    subgraph depth2 {
-      depth2_node1;
-      depth2_node2;
-      depth2_node1 -- depth2_node2;
+  \\"node1\\";
+  \\"node2\\";
+  subgraph \\"depth1\\" {
+    \\"depth1_node1\\";
+    \\"depth1_node2\\";
+    subgraph \\"depth2\\" {
+      \\"depth2_node1\\";
+      \\"depth2_node2\\";
+      \\"depth2_node1\\" -- \\"depth2_node2\\";
     }
-    depth1_node1 -- depth1_node2;
+    \\"depth1_node1\\" -- \\"depth1_node2\\";
   }
-  node1 -- node2;
+  \\"node1\\" -- \\"node2\\";
 }"
 `;

--- a/src/model/__test__/__snapshots__/Node.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Node.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`class Node renders correctly by toDot method has some attributes 1`] = `
-"test [
+"\\"test\\" [
   label = \\"this is test\\",
-  color = red,
+  color = \\"red\\",
 ];"
 `;
 
 exports[`class Node renders correctly by toDot method node with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
-test;"
+\\"test\\";"
 `;
 
 exports[`class Node renders correctly by toDot method node with comment single line comment 1`] = `
 "// this is comment.
-test;"
+\\"test\\";"
 `;
 
-exports[`class Node renders correctly by toDot method simple node 1`] = `"test;"`;
+exports[`class Node renders correctly by toDot method simple node 1`] = `"\\"test\\";"`;

--- a/src/model/__test__/__snapshots__/Subgraph.spec.ts.snap
+++ b/src/model/__test__/__snapshots__/Subgraph.spec.ts.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`class Subgraph root is Digraph addXxx existXxx removeXxx APIs Edge operation methods works 1`] = `
-"subgraph test {
-  node1;
-  node2;
-  node1 -- node2;
+"subgraph \\"test\\" {
+  \\"node1\\";
+  \\"node2\\";
+  \\"node1\\" -- \\"node2\\";
 }"
 `;
 
 exports[`class Subgraph root is Digraph addXxx existXxx removeXxx APIs Subgraph operation methods works 1`] = `
-"subgraph test {
-  subgraph sub {
+"subgraph \\"test\\" {
+  subgraph \\"sub\\" {
   }
 }"
 `;
 
 exports[`class Subgraph root is Digraph label attribute behavior html like 1`] = `
-"subgraph test {
+"subgraph \\"test\\" {
   graph [
     label = <<B>this is test for graph label</B>>,
   ];
@@ -30,7 +30,7 @@ exports[`class Subgraph root is Digraph label attribute behavior html like 1`] =
 `;
 
 exports[`class Subgraph root is Digraph label attribute behavior plain text label to be quoted by double quotation 1`] = `
-"subgraph test {
+"subgraph \\"test\\" {
   graph [
     label = \\"this is test for graph label\\",
   ];
@@ -45,16 +45,16 @@ exports[`class Subgraph root is Digraph label attribute behavior plain text labe
 
 exports[`class Subgraph root is Digraph set attributes 1`] = `
 "digraph {
-  subgraph test {
-    rank = same;
+  subgraph \\"test\\" {
+    rank = \\"same\\";
   }
 }"
 `;
 
 exports[`class Subgraph root is Digraph set attributes by apply 1`] = `
 "digraph {
-  subgraph test {
-    rank = same;
+  subgraph \\"test\\" {
+    rank = \\"same\\";
   }
 }"
 `;
@@ -62,33 +62,33 @@ exports[`class Subgraph root is Digraph set attributes by apply 1`] = `
 exports[`class Subgraph root is Digraph subgraph with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
-subgraph test {
+subgraph \\"test\\" {
 }"
 `;
 
 exports[`class Subgraph root is Digraph subgraph with comment single line comment 1`] = `
 "// this is comment.
-subgraph test {
+subgraph \\"test\\" {
 }"
 `;
 
 exports[`class Subgraph root is Graph addXxx existXxx removeXxx APIs Edge operation methods works 1`] = `
-"subgraph test {
-  node1;
-  node2;
-  node1 -- node2;
+"subgraph \\"test\\" {
+  \\"node1\\";
+  \\"node2\\";
+  \\"node1\\" -- \\"node2\\";
 }"
 `;
 
 exports[`class Subgraph root is Graph addXxx existXxx removeXxx APIs Subgraph operation methods works 1`] = `
-"subgraph test {
-  subgraph sub {
+"subgraph \\"test\\" {
+  subgraph \\"sub\\" {
   }
 }"
 `;
 
 exports[`class Subgraph root is Graph label attribute behavior html like 1`] = `
-"subgraph test {
+"subgraph \\"test\\" {
   graph [
     label = <<B>this is test for graph label</B>>,
   ];
@@ -102,7 +102,7 @@ exports[`class Subgraph root is Graph label attribute behavior html like 1`] = `
 `;
 
 exports[`class Subgraph root is Graph label attribute behavior plain text label to be quoted by double quotation 1`] = `
-"subgraph test {
+"subgraph \\"test\\" {
   graph [
     label = \\"this is test for graph label\\",
   ];
@@ -117,16 +117,16 @@ exports[`class Subgraph root is Graph label attribute behavior plain text label 
 
 exports[`class Subgraph root is Graph set attributes 1`] = `
 "graph {
-  subgraph test {
-    rank = same;
+  subgraph \\"test\\" {
+    rank = \\"same\\";
   }
 }"
 `;
 
 exports[`class Subgraph root is Graph set attributes by apply 1`] = `
 "graph {
-  subgraph test {
-    rank = same;
+  subgraph \\"test\\" {
+    rank = \\"same\\";
   }
 }"
 `;
@@ -134,12 +134,12 @@ exports[`class Subgraph root is Graph set attributes by apply 1`] = `
 exports[`class Subgraph root is Graph subgraph with comment multi line comment 1`] = `
 "// this is comment.
 // second line.
-subgraph test {
+subgraph \\"test\\" {
 }"
 `;
 
 exports[`class Subgraph root is Graph subgraph with comment single line comment 1`] = `
 "// this is comment.
-subgraph test {
+subgraph \\"test\\" {
 }"
 `;


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

There are several cases where quote should be used for IDs but didn't implement, such as:

1. When label is "node", it should be quoted, otherwise dot can't parse it correctly (i.e. `label = node` results in syntax error);
2. When label contains `.`, it should be marked in quote.

### How this PR fixes the problem

I think it might be safe to simply quote all IDs, no matter it's necessary or not.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
