### PR TITLE
Improve Attributes API

### DIFF
--- a/src/model/AttributesBase.ts
+++ b/src/model/AttributesBase.ts
@@ -1,5 +1,5 @@
 import { DotBase } from '../abstract';
-import { IAttributesBase } from '../types';
+import { AttributesObject, AttributesValue, IAttributesBase } from '../types';
 import { ID } from './ID';
 /**
  * @hidden
@@ -16,17 +16,21 @@ export abstract class AttributesBase<T extends string> extends DotBase implement
     return this.attrs.get(key);
   }
   /** Set a value to the attribute. */
-  public set(key: T, value: string | boolean | number | ID): void {
-    if (value instanceof ID) {
-      this.attrs.set(key, value);
-    } else {
-      this.attrs.set(key, new ID(value));
+  public set(key: T, value: AttributesValue): void {
+    this.attrs.set(key, new ID(value));
+  }
+
+  public delete(key: T): void {
+    this.attrs.delete(key);
+  }
+
+  public apply(attributes: AttributesObject<T>) {
+    for (const [key, value] of Object.entries(attributes)) {
+      this.set(key as T, value as string | boolean | number);
     }
   }
 
-  public apply(attributes: { [key in T]?: string | boolean | number | ID }) {
-    for (const [key, value] of Object.entries(attributes)) {
-      this.set(key as T, value as string | boolean | number | ID);
-    }
+  public clear() {
+    this.attrs.clear();
   }
 }

--- a/src/model/__test__/Attributes.spec.ts
+++ b/src/model/__test__/Attributes.spec.ts
@@ -46,10 +46,23 @@ describe('class Attributes', () => {
       expect(attrs.toDot()).toMatchSnapshot();
     });
 
-    test('set/get attribute', () => {
-      const id = new ID('test');
+    test('apply/clear attribute', () => {
+      attrs.apply({
+        label: 'this is test',
+        color: 'red',
+        fontsize: 16,
+      });
+      expect(attrs.size).toBe(3);
+      attrs.clear();
+      expect(attrs.size).toBe(0);
+    });
+
+    test('set/get/delete attribute', () => {
+      const id = 'test';
       attrs.set('label', id);
-      expect(attrs.get('label')).toBe(id);
+      expect(attrs.get('label')?.value).toBe(id);
+      attrs.delete('label');
+      expect(attrs.get('label')).toBeUndefined();
     });
 
     describe('edge with comment', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,11 +130,24 @@ export interface IID extends IDot {
   readonly value: string;
 }
 
+export type AttributesValue = string | number | boolean;
+
+export type AttributesObject<T extends string> = {
+  [key in T]?: AttributesValue;
+};
+
+export type EdgeAttributes = AttributesObject<attribute.Edge>;
+export type NodeAttributes = AttributesObject<attribute.Node>;
+export type RootClusterAttributes = AttributesObject<attribute.RootCluster>;
+export type ClusterSubgraphAttributes = AttributesObject<attribute.ClusterSubgraph>;
+
 export interface IAttributesBase<T extends string> {
   readonly size: number;
   get(key: T): IID | undefined;
-  set(key: T, value: string | boolean | number | IID): void;
-  apply(attributes: { [key in T]?: string | boolean | number | IID }): void;
+  set(key: T, value: AttributesValue): void;
+  apply(attributes: AttributesObject<T>): void;
+  delete(key: T): void;
+  clear(): void;
 }
 
 export interface IAttributes<T extends string> extends IAttributesBase<T>, IHasComment, IDot {}


### PR DESCRIPTION
### What was a problem

There was no API that can delete/clear the contents of `Attributes`.

### How this PR fixes the problem

Improved API of `Attributes` class and added type information.

- add `delete/clear` methods to `BaseAttributes` .
- add `XxxAttributes` type.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
