### PR TITLE
Upgrade Peggy and remove ts-pegjs dependency

### DIFF
--- a/.changeset/eighty-insects-cheer.md
+++ b/.changeset/eighty-insects-cheer.md
@@ -13,3 +13,4 @@ Update Develop Environment
 - Upgrade TypeScript to 5.8.3
 - Upgrade Vite to 6.3.5
 - Upgrade Vitest to 3.1.3
+- Upgrade Peggy to 5.0.3 and drop ts-pegjs

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,10 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": ["./packages/ast/src/dot-shim/parser/_parse.ts"]
+    "ignore": [
+      "./packages/ast/src/dot-shim/parser/_parse.js",
+      "./packages/ast/src/dot-shim/parser/_parse.d.ts"
+    ]
   },
   "organizeImports": {
     "enabled": true

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -31,14 +31,13 @@
   },
   "scripts": {
     "build": "vite build",
-    "codegen": "peggy --plugin ts-pegjs --extra-options-file src/dot-shim/parser/peggy.options.json -o src/dot-shim/parser/_parse.ts src/dot-shim/parser/dot.peggy"
+    "codegen": "peggy --dts -d \"{ Builder }:../../builder/index.js\" --extra-options-file src/dot-shim/parser/peggy.options.json -o src/dot-shim/parser/_parse.js src/dot-shim/parser/dot.peggy"
   },
   "dependencies": {
     "@ts-graphviz/common": "workspace:^"
   },
   "devDependencies": {
-    "peggy": "^4.0.3",
-    "ts-pegjs": "^4.2.1",
+    "peggy": "^5.0.3",
     "typescript": "^5.8.2",
     "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.3"

--- a/packages/ast/src/dot-shim/parser/.gitignore
+++ b/packages/ast/src/dot-shim/parser/.gitignore
@@ -1,1 +1,1 @@
-_parse.ts
+_parse.*

--- a/packages/ast/src/dot-shim/parser/dot.peggy
+++ b/packages/ast/src/dot-shim/parser/dot.peggy
@@ -5,7 +5,7 @@
  */
 
 {
-  function dedent(value: string): string {
+  function dedent(value) {
     const str = value.trim();
     const matches = str.match(/\n([\t ]+|(?!\s).)/g);
     if (matches) {
@@ -16,7 +16,7 @@
     return str;
   }
 
-  const edgeops: { operator: '--' | '->', location: FileRange }[] = [];
+  const edgeops = [];
 
   const b = new Builder({
     locationFunction: location,

--- a/packages/ast/src/dot-shim/parser/parse.ts
+++ b/packages/ast/src/dot-shim/parser/parse.ts
@@ -9,19 +9,16 @@ import type {
   NodeASTNode,
   SubgraphASTNode,
 } from '../../types.js';
-import { PeggySyntaxError, parse as _parse } from './_parse.js';
+import {
+  SyntaxError as PeggySyntaxError,
+  type StartRuleNames,
+  parse as _parse,
+} from './_parse.js';
+
 /**
  * @group Convert DOT to AST
  */
-export type Rule =
-  | 'Dot'
-  | 'Graph'
-  | 'Node'
-  | 'Edge'
-  | 'AttributeList'
-  | 'Attribute'
-  | 'Subgraph'
-  | 'ClusterStatements';
+export type Rule = StartRuleNames;
 
 /**
  * CommonParseOptions is an interface that defines the properties needed in order to parse a file.
@@ -101,8 +98,9 @@ export function parse(
   input: string,
   options?: ParseOptions<Rule>,
 ): ASTNode | ClusterStatementASTNode[] {
+  const { startRule, filename } = options ?? {};
   try {
-    return _parse(input, options);
+    return _parse(input, { startRule, filename });
   } catch (e) {
     if (e instanceof PeggySyntaxError) {
       throw new DotSyntaxError(e.message, {

--- a/packages/ast/src/dot-shim/parser/peggy.options.json
+++ b/packages/ast/src/dot-shim/parser/peggy.options.json
@@ -9,7 +9,5 @@
     "Attribute",
     "ClusterStatements"
   ],
-  "tspegjs": {
-    "customHeader": "import { Builder } from '../../builder/index.js';"
-  }
+  "format": "es"
 }

--- a/packages/ts-graphviz/tsconfig.json
+++ b/packages/ts-graphviz/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "removeComments": true
+    "removeComments": true,
+    "allowJs": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "**/__tests__/***/*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,11 +112,8 @@ importers:
         version: link:../common
     devDependencies:
       peggy:
-        specifier: ^4.0.3
-        version: 4.0.3
-      ts-pegjs:
-        specifier: ^4.2.1
-        version: 4.2.1(peggy@4.0.3)
+        specifier: ^5.0.3
+        version: 5.0.3
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -1229,11 +1226,11 @@ packages:
       semver: 7.7.2
     dev: true
 
-  /@peggyjs/from-mem@1.3.0:
-    resolution: {integrity: sha512-kzGoIRJjkg3KuGI4bopz9UvF3KguzfxalHRDEIdqEZUe45xezsQ6cx30e0RKuxPUexojQRBfu89Okn7f4/QXsw==}
-    engines: {node: '>=18'}
+  /@peggyjs/from-mem@2.0.0:
+    resolution: {integrity: sha512-f+pL/s2DiT+2dxwheSoJT0P/KJy/s0klzE+ZqRdXHlkeyFk/DpKtyjLZIiA79kx56g3oEPA8Zu9EzEKzAwuvhw==}
+    engines: {node: '>=20'}
     dependencies:
-      semver: 7.6.0
+      semver: 7.7.1
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -2893,15 +2890,6 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /@ts-morph/common@0.19.0:
-    resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
-    dependencies:
-      fast-glob: 3.3.2
-      minimatch: 7.4.6
-      mkdirp: 2.1.6
-      path-browserify: 1.0.1
-    dev: true
-
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: true
@@ -4066,10 +4054,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
-  /code-block-writer@12.0.0:
-    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
-    dev: true
-
   /code-point-at@1.1.0:
     resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
     engines: {node: '>=0.10.0'}
@@ -4109,9 +4093,9 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
-  /commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
+  /commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
     dev: true
 
   /commander@7.2.0:
@@ -6558,12 +6542,6 @@ packages:
     hasBin: true
     dev: true
 
-  /mkdirp@2.1.6:
-    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
   /mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
@@ -7153,14 +7131,14 @@ packages:
       through2: 2.0.5
     dev: true
 
-  /peggy@4.0.3:
-    resolution: {integrity: sha512-v7/Pt6kGYsfXsCrfb52q7/yg5jaAwiVaUMAPLPvy4DJJU6Wwr72t6nDIqIDkGfzd1B4zeVuTnQT0RGeOhe/uSA==}
-    engines: {node: '>=18'}
+  /peggy@5.0.3:
+    resolution: {integrity: sha512-QErYmLjj/ehiNNJRqx2qb36hzkanuascpMqREs2RQqaXhU3cflIRScP/u2BoobIfu/FaeI3GGxNB/vFX/Ar9lg==}
+    engines: {node: '>=20'}
     hasBin: true
     dependencies:
-      '@peggyjs/from-mem': 1.3.0
-      commander: 12.1.0
-      source-map-generator: 0.8.0
+      '@peggyjs/from-mem': 2.0.0
+      commander: 14.0.0
+      source-map-generator: 2.0.0
     dev: true
 
   /performance-now@2.1.0:
@@ -7818,14 +7796,6 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
@@ -8066,9 +8036,9 @@ packages:
       is-plain-obj: 2.1.0
     dev: true
 
-  /source-map-generator@0.8.0:
-    resolution: {integrity: sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==}
-    engines: {node: '>= 10'}
+  /source-map-generator@2.0.0:
+    resolution: {integrity: sha512-4KomB7QsJti7dFBAVF6SXHzuCNQauk4gE2CummcqPzl+eJqXz1CkkiBdVXXW3g8VGh23bxcdEVACOzrxpIqnUg==}
+    engines: {node: '>=20'}
     dev: true
 
   /source-map-js@1.2.1:
@@ -8523,24 +8493,6 @@ packages:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
     dependencies:
       utf8-byte-length: 1.0.5
-    dev: true
-
-  /ts-morph@18.0.0:
-    resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
-    dependencies:
-      '@ts-morph/common': 0.19.0
-      code-block-writer: 12.0.0
-    dev: true
-
-  /ts-pegjs@4.2.1(peggy@4.0.3):
-    resolution: {integrity: sha512-mK/O2pu6lzWUeKpEMA/wsa0GdYblfjJI1y0s0GqH6xCTvugQDOWPJbm5rY6AHivpZICuXIriCb+a7Cflbdtc2w==}
-    hasBin: true
-    peerDependencies:
-      peggy: ^3.0.2
-    dependencies:
-      peggy: 4.0.3
-      prettier: 2.8.8
-      ts-morph: 18.0.0
     dev: true
 
   /tsconfck@3.1.5(typescript@5.8.3):


### PR DESCRIPTION
Upgrade Peggy to version 5.0.3 and eliminate the ts-pegjs dependency, streamlining the codebase and improving compatibility. Adjustments made to related scripts and configurations to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the Peggy parser generator to version 5.0.3 and removed the ts-pegjs dependency.
	- Updated development scripts and configuration files to reflect the new parser setup.
	- Broadened file ignore patterns to include additional generated files.
	- Enabled JavaScript file processing in the TypeScript configuration for improved compatibility.

- **Refactor**
	- Adjusted parser implementation and configuration to align with updated dependencies and output formats.
	- Simplified type annotations in the parser grammar for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->