### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.changeset/fix-missing-startrulenames-type.md
+++ b/.changeset/fix-missing-startrulenames-type.md
@@ -1,0 +1,17 @@
+---
+"@ts-graphviz/ast": patch
+---
+
+Fix TypeScript compilation error when skipLibCheck is false
+
+This fixes issue #1478 where importing from `ts-graphviz` would cause a TypeScript error:
+"Cannot find module './_parse.js' or its corresponding type declarations."
+
+The issue was caused by the `Rule` type referencing `StartRuleNames` from the auto-generated
+`_parse.ts` file, which was not properly exported. The fix removes the dependency on the
+generated type and defines the `Rule` type directly in `parse.ts`.
+
+Changes:
+- Remove import of non-existent `StartRuleNames` type from `_parse.ts`
+- Fix import of `PeggySyntaxError` to use the correct export name
+- Define `Rule` type directly as a union of rule name string literals

--- a/.changeset/thirty-rice-jog.md
+++ b/.changeset/thirty-rice-jog.md
@@ -1,0 +1,10 @@
+---
+"@ts-graphviz/adapter": patch
+"@ts-graphviz/ast": patch
+"@ts-graphviz/common": patch
+"@ts-graphviz/core": patch
+"@ts-graphviz/react": patch
+"ts-graphviz": patch
+---
+
+Fix CI workflow to prevent publishing stable releases with @next tag

--- a/packages/adapter/CHANGELOG.md
+++ b/packages/adapter/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @ts-graphviz/adapter
 
-## 3.0.1
-
-### Patch Changes
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
-- Updated dependencies [[`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6)]:
-  - @ts-graphviz/common@3.0.1
-
 ## 3.0.0
 
 ### Major Changes

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-graphviz/adapter",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Graphviz Runtime adapters for Cross Platform",
   "keywords": [
     "graphviz",

--- a/packages/ast/CHANGELOG.md
+++ b/packages/ast/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @ts-graphviz/ast
 
-## 3.0.1
-
-### Patch Changes
-
-- [#1479](https://github.com/ts-graphviz/ts-graphviz/pull/1479) [`c9653aa`](https://github.com/ts-graphviz/ts-graphviz/commit/c9653aa75cb13a91d6a6bcbd8b64161cfd0273b5) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix TypeScript compilation error when skipLibCheck is false
-
-  This fixes issue #1478 where importing from `ts-graphviz` would cause a TypeScript error:
-  "Cannot find module './\_parse.js' or its corresponding type declarations."
-
-  The issue was caused by the `Rule` type referencing `StartRuleNames` from the auto-generated
-  `_parse.ts` file, which was not properly exported. The fix removes the dependency on the
-  generated type and defines the `Rule` type directly in `parse.ts`.
-
-  Changes:
-
-  - Remove import of non-existent `StartRuleNames` type from `_parse.ts`
-  - Fix import of `PeggySyntaxError` to use the correct export name
-  - Define `Rule` type directly as a union of rule name string literals
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
-- Updated dependencies [[`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6)]:
-  - @ts-graphviz/common@3.0.1
-
 ## 3.0.0
 
 ### Major Changes

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-graphviz/ast",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Graphviz AST(Abstract Syntax Tree) Utilities",
   "keywords": [],
   "homepage": "https://github.com/ts-graphviz/ts-graphviz#readme",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @ts-graphviz/common
 
-## 3.0.1
-
-### Patch Changes
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
 ## 3.0.0
 
 ### Major Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-graphviz/common",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Graphviz Types and Utilities",
   "keywords": [
     "graphviz",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @ts-graphviz/core
 
-## 3.0.1
-
-### Patch Changes
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
-- Updated dependencies [[`c9653aa`](https://github.com/ts-graphviz/ts-graphviz/commit/c9653aa75cb13a91d6a6bcbd8b64161cfd0273b5), [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6)]:
-  - @ts-graphviz/ast@3.0.1
-  - @ts-graphviz/common@3.0.1
-
 ## 3.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-graphviz/core",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Graphviz Models for Object-Oriented Programming",
   "keywords": [
     "graphviz",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @ts-graphviz/react
 
-## 0.11.1
-
-### Patch Changes
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
-- Updated dependencies [[`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6)]:
-  - @ts-graphviz/common@3.0.1
-  - ts-graphviz@3.0.1
-
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-graphviz/react",
-  "version": "0.11.1",
+  "version": "0.11.0",
   "description": "Graphviz-dot Renderer for React.",
   "keywords": [
     "graphviz",

--- a/packages/ts-graphviz/CHANGELOG.md
+++ b/packages/ts-graphviz/CHANGELOG.md
@@ -1,17 +1,5 @@
 # ts-graphviz
 
-## 3.0.1
-
-### Patch Changes
-
-- [#1480](https://github.com/ts-graphviz/ts-graphviz/pull/1480) [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6) Thanks [@kamiazya](https://github.com/kamiazya)! - Fix CI workflow to prevent publishing stable releases with @next tag
-
-- Updated dependencies [[`c9653aa`](https://github.com/ts-graphviz/ts-graphviz/commit/c9653aa75cb13a91d6a6bcbd8b64161cfd0273b5), [`ab5d0c7`](https://github.com/ts-graphviz/ts-graphviz/commit/ab5d0c75620a0fd1bf36373716b26c2d433a0bc6)]:
-  - @ts-graphviz/ast@3.0.1
-  - @ts-graphviz/adapter@3.0.1
-  - @ts-graphviz/common@3.0.1
-  - @ts-graphviz/core@3.0.1
-
 ## 3.0.0
 
 ### Major Changes

--- a/packages/ts-graphviz/package.json
+++ b/packages/ts-graphviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graphviz",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Graphviz library for TypeScript",
   "keywords": [
     "graphviz",


### PR DESCRIPTION
Reverts ts-graphviz/ts-graphviz#1481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved a TypeScript compile error in strict projects by defining explicit rule name types.
  - Corrected error export usage to prevent import/runtime issues.

- Chores
  - Updated release workflow to avoid publishing stable releases with the @next tag.
  - Realigned package versions to previous stable (e.g., 3.0.0 core packages, 0.11.0 React) for consistency.

- Documentation
  - Cleaned up CHANGELOGs to match version alignment, removing unintended patch notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->